### PR TITLE
fix: broken contact links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
 
 <h3 align="left">Connect with me:</h3>
 <p align="left">
-<a href="https://dev.to/https://dev.to/dev_elie" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/devto.svg" alt="https://dev.to/dev_elie" height="30" width="40" /></a>
+<a href="https://dev.to/dev_elie" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/devto.svg" alt="https://dev.to/dev_elie" height="30" width="40" /></a>
 <a href="https://twitter.com/dev_elie" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="dev_elie" height="30" width="40" /></a>
-<a href="https://linkedin.com/in/https://www.linkedin.com/in/ondiek-elijah-2aaba4198/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="https://www.linkedin.com/in/ondiek-elijah-2aaba4198/" height="30" width="40" /></a>
-<a href="https://stackoverflow.com/users/https://stackoverflow.com/users/12943692/dev-elie" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/stack-overflow.svg" alt="https://stackoverflow.com/users/12943692/dev-elie" height="30" width="40" /></a>
+<a href="https://www.linkedin.com/in/ondiek-elijah-2aaba4198/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="https://www.linkedin.com/in/ondiek-elijah-2aaba4198/" height="30" width="40" /></a>
+<a href="https://stackoverflow.com/users/12943692/dev-elie" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/stack-overflow.svg" alt="https://stackoverflow.com/users/12943692/dev-elie" height="30" width="40" /></a>
 </p>
 
 <h3 align="left">Languages and Tools:</h3>


### PR DESCRIPTION
Your contact links for _dev.to_, _linkedin_ and the _stack overflow_ were broken because of a duplication in the url path.
BTW: Nice profile 😊